### PR TITLE
Print a message if `set -e` aborts the script.

### DIFF
--- a/bash-simple
+++ b/bash-simple
@@ -131,6 +131,14 @@ set -o nounset
 # Short form: set -e
 set -o errexit
 
+# Print a helpful message if a pipeline with non-zero exit code causes the
+# script to exit as described above.
+trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
+
+# Allow the above trap be inherited by all functions in the script.
+# Short form: set -E
+set -o errtrace
+
 # Return value of a pipeline is the value of the last (rightmost) command to
 # exit with a non-zero status, or zero if all commands in the pipeline exit
 # successfully.


### PR DESCRIPTION
Currently, if a command fails, it will just silently abort the script.
This commit adds a helpful message on stderr with reason, line number
and exit code.
